### PR TITLE
handle low N values better when setting limts

### DIFF
--- a/probscale/tests/test_viz.py
+++ b/probscale/tests/test_viz.py
@@ -686,7 +686,8 @@ def test_probplot_test_results(plot_data):
 
 @pytest.mark.parametrize('probax', ['x', 'y'])
 @pytest.mark.parametrize(('N', 'minval', 'maxval'), [
-    (8, 10, 90),
+    (5, 10, 90),
+    (8, 5, 95),
     (37, 1, 99),
     (101, 0.1, 99.9),
     (10001, 0.001, 99.999)

--- a/probscale/viz.py
+++ b/probscale/viz.py
@@ -361,7 +361,13 @@ def _set_prob_limits(ax, probax, N):
     fig, ax = validate.axes_object(ax)
     which = validate.axis_name(probax, 'probability axis')
 
-    minval = 10 ** (-1 *numpy.ceil(numpy.log10(N) - 2))
+    if N <= 5:
+        minval = 10
+    elif N <= 10:
+        minval = 5
+    else:
+        minval = 10 ** (-1 * numpy.ceil(numpy.log10(N) - 2))
+
     if which in ['x', 'both']:
         ax.set_xlim(left=minval, right=100-minval)
     elif which in ['y', 'both']:


### PR DESCRIPTION
Issue was that N = 10 was returning 10 and 90 as exes limits, but that's tool narrow -- min and max are ~8 and ~92 for Cunnane plotting positions.